### PR TITLE
Make new from builder consistent with Laravel Core

### DIFF
--- a/src/ReturnsChildModels.php
+++ b/src/ReturnsChildModels.php
@@ -25,7 +25,13 @@ trait ReturnsChildModels
 
     public function newFromBuilder($attributes = [], $connection = null)
     {
-        return $this->newInstance((array) $attributes, true);
+        $model = $this->newInstance((array) $attributes, true);
+        
+        $model->setConnection($connection ?: $this->getConnectionName());
+        
+        $model->fireModelEvent('retrieved', false);
+        
+        return $model;
     }
 
     public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1517011/41123536-96186b96-6a64-11e8-9660-58f09f364da3.png)

Adds the use of the connection param and fires the `retrieved` event.