### PR TITLE
childField => childColumn, fixed typo

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -10,7 +10,7 @@ trait HasChildren
 
     public function newInstance($attributes = [], $exists = false)
     {
-        $model = isset($attributes[$this->getInhertanceColumn()])
+        $model = isset($attributes[$this->getInheritanceColumn()])
             ? $this->getChildModel($attributes)
             : new static(((array) $attributes));
 
@@ -72,15 +72,15 @@ trait HasChildren
         return class_basename($this);
     }
 
-    public function getInhertanceColumn()
+    public function getInheritanceColumn()
     {
-        return $this->childField ?: 'type';
+        return $this->childColumn ?: 'type';
     }
 
     protected function getChildModel(array $attributes)
     {
         $className = $this->classFromAlias(
-            $attributes[$this->getInhertanceColumn()]
+            $attributes[$this->getInheritanceColumn()]
         );
 
         return new $className((array)$attributes);

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -14,7 +14,7 @@ trait HasParent
         static::creating(function ($model) {
             if ($model->parentHasHasChildrenTrait()) {
                 $model->forceFill(
-                    [$model->getInhertanceColumn() => $model->classToAlias(get_class($model))]
+                    [$model->getInheritanceColumn() => $model->classToAlias(get_class($model))]
                 );
             }
         });
@@ -23,7 +23,7 @@ trait HasParent
             $instance = new static;
 
             if ($instance->parentHasHasChildrenTrait()) {
-                $query->where($instance->getInhertanceColumn(), $instance->classToAlias(get_class($instance)));
+                $query->where($instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
             }
         });
     }

--- a/tests/Models/Trip.php
+++ b/tests/Models/Trip.php
@@ -9,7 +9,7 @@ class Trip extends Model
 {
     use HasChildren;
 
-    protected $childField = 'trip_type';
+    protected $childColumn = 'trip_type';
 
     protected $guarded = [];
 


### PR DESCRIPTION
Cool package, this looks very useful! The `childField` didn't match the latest update to the docs and I noticed a typo in one of the methods. Thanks! 👍 
