### PR TITLE
Improves support for Laravel Nova

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,20 @@ class User extends Model
 }
 ```
 
+## Laravel Nova Support
+If you want to use share parent Nova resources with child models, you may register the following provider at the end of the boot method of your NovaServiceProvider:
+
+```php
+class NovaServiceProvider extends NovaApplicationServiceProvider
+{
+    public function boot() {
+        parent::boot();
+        // ...
+        $this->app->register(\Tightenco\Parental\Providers\NovaResourceProvider::class);
+    }
+}
+```
+
 ---
 
 Thanks to [@sschoger](https://twitter.com/steveschoger) for the sick logo design, and [@DanielCoulbourne](https://twitter.com/DCoulbourne) for helping brainstorm the idea on [Twenty Percent Time](http://twentypercent.fm/).

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -107,4 +107,9 @@ trait HasChildren
 
         return $className;
     }
+
+    public function getChildTypes()
+    {
+        return property_exists($this, 'childTypes') ? $this->childTypes : [];
+    }
 }

--- a/src/Providers/NovaResourceProvider.php
+++ b/src/Providers/NovaResourceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tightenco\Parental\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Laravel\Nova\Nova;
+use Tightenco\Parental\HasChildren;
+use Tightenco\Parental\HasParent;
+
+class NovaResourceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        if (class_exists(Nova::class)) {
+            Nova::serving(function () {
+                $this->setNovaResources();
+            });
+        }
+    }
+
+    protected function setNovaResources()
+    {
+        $map = [];
+        foreach (Nova::$resources as $resource) {
+            $parent = $resource::$model;
+            $map[$parent] = $resource;
+            $traits = class_uses_recursive($parent);
+            if (isset($traits[HasChildren::class]) && ! isset($traits[HasParent::class])) {
+                foreach ((new $parent)->getChildTypes() as $child) {
+                    if (! isset($map[$child])) {
+                        $map[$child] = $resource;
+                    }
+                }
+            }
+        }
+        Nova::$resourcesByModel = array_merge($map, Nova::$resourcesByModel);
+    }
+}


### PR DESCRIPTION
Issue #28 

Registering NovaResourceProvider will set the parent resource for the child models (won't apply to children that have a dedicated resource)

Usage: in your NovaServiceProvider, just add the new provider at the end of the boot method
```
class NovaServiceProvider extends NovaApplicationServiceProvider
{
    public function boot() {
        parent::boot();
        // ...
        $this->app->register(\Tightenco\Parental\Providers\NovaResourceProvider::class);
    }
}
```