### PR TITLE
Use the parent's morph class if parent returns children

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -68,6 +68,15 @@ trait HasParent
         return class_basename($this->getParentClass());
     }
 
+    public function getMorphClass()
+    {
+        if ($this->parentHasHasChildrenTrait() && in_array(static::class, $this->getChildTypes())) {
+            $parentClass = $this->getParentClass();
+            return (new $parentClass)->getMorphClass();
+        }
+        return parent::getMorphClass();
+    }
+
     protected function getParentClass()
     {
         static $parentClassName;

--- a/tests/Features/PolymorphismTest.php
+++ b/tests/Features/PolymorphismTest.php
@@ -4,6 +4,7 @@ namespace Tightenco\Parental\Tests\Features;
 
 use Tightenco\Parental\Tests\Models\Car;
 use Tightenco\Parental\Tests\Models\Part;
+use Tightenco\Parental\Tests\Models\Passenger;
 use Tightenco\Parental\Tests\Models\Vehicle;
 use Tightenco\Parental\Tests\TestCase;
 
@@ -35,5 +36,122 @@ class PolymorphismTest extends TestCase
 
         $this->assertTrue($car->is($part->vehicles()->get()->pop()));
         $this->assertInstanceOf(Car::class, $part->vehicles()->get()->pop());
+    }
+
+    /** @test */
+    public function can_query_where_has_one()
+    {
+        $_1 = Part::create(['type' => 'tire']);
+        $_2 = Part::create(['type' => 'wing']);
+        $_3 = Part::create(['type' => 'engine']);
+        $_4 = Part::create(['type' => 'seat']);
+        $_5 = Part::create(['type' => 'some metal thing']);
+        $_6 = Part::create(['type' => 'i dont know car parts w/e']);
+
+        /** @var Car $car */
+        $car = Car::create([]);
+        /** @var Vehicle $vehicle */
+        $vehicle = Vehicle::create([]);
+
+        $car->parts()->attach($_1);
+        $car->parts()->attach($_2);
+        $car->parts()->attach($_3);
+
+        $vehicle->parts()->attach($_4);
+        $vehicle->parts()->attach($_5);
+        $vehicle->parts()->attach($_6);
+
+        $this->assertNull(Car::query()->whereHas('parts', function ($query) {
+            $query->where('type', 'seat');
+        })->first());
+
+        $checker = Vehicle::query()->whereHas('parts', function ($query) {
+            $query->where('type', 'tire');
+        })->first();
+
+        $this->assertNotNull($checker);
+        $this->assertTrue($car->is($checker));
+        $this->assertInstanceOf(Car::class, $checker);
+    }
+
+    /** @test */
+    public function can_query_where_has_two()
+    {
+        /** @var Part $part */
+        Part::create();
+        Part::create();
+        $part = Part::create();
+        Part::create();
+        $otherPart = Part::create();
+        Part::create();
+        /** @var Car $car */
+        $car = Car::create([]);
+        /** @var Vehicle $vehicle */
+        $vehicle = Vehicle::create([]);
+        $part->vehicles()->create([]);
+        $part->vehicles()->attach($vehicle);
+        $part->vehicles()->attach($car);
+
+        $otherPart->vehicles()->create([]);
+        $otherPart->vehicles()->create([]);
+        $otherPart->vehicles()->create([]);
+        $otherPart->vehicles()->attach($vehicle);
+
+        $car->passengers()->create(['name' => 'Robert']);
+        $car->passengers()->create(['name' => 'Joe']);
+        $car->passengers()->create(['name' => 'John']);
+        $vehicle->passengers()->create(['name' => 'Bob']);
+        $vehicle->passengers()->create(['name' => 'Karl']);
+
+        $checker = Part::query()
+            ->whereHas('vehicles.passengers', function ($query) {
+                $query->where('name', 'Robert');
+            })
+            ->first();
+
+        $this->assertTrue($part->is($checker));
+
+        $checker = Part::query()
+            ->whereHas('vehicles.passengers', function ($query) {
+                $query->where('name', 'Robert');
+            })
+            ->with(['vehicles.passengers' => function ($query) {
+                $query->where('name', 'Robert');
+            }])
+            ->first();
+
+        $this->assertTrue($car->is($checker->vehicles()->first()));
+        $this->assertEquals('Robert', $checker->vehicles()->first()->passengers()->first()->name);
+    }
+
+    /** @test */
+    public function can_query_where_has_three()
+    {
+        /** @var Car $car */
+        $car = Car::create();
+        /** @var Vehicle $vehicle */
+        $vehicle = Vehicle::create();
+
+        $joe = Passenger::create(['name' => 'joe', 'vehicle_id' => $car->id]);
+        Passenger::create(['name' => 'john', 'vehicle_id' => $vehicle->id]);
+        Passenger::create(['name' => 'carl', 'vehicle_id' => $car->id]);
+        Passenger::create(['name' => 'tony', 'vehicle_id' => $vehicle->id]);
+        Passenger::create(['name' => 'robert', 'vehicle_id' => $car->id]);
+
+        $car->parts()->create(['type' => 'tire']);
+        $car->parts()->create(['type' => 'some']);
+        $car->parts()->create(['type' => 'type']);
+        $vehicle->parts()->create(['type' => 'and']);
+        $vehicle->parts()->create(['type' => 'some']);
+        $vehicle->parts()->create(['type' => 'other']);
+
+        $passenger = Passenger::query()->whereHas('vehicle.parts', function ($query) {
+            $query->where('type', 'tire');
+        })->first();
+
+        $this->assertNotNull($passenger);
+        $this->assertTrue($joe->is($passenger));
+        $this->assertTrue($car->is($passenger->vehicle));
+        $this->assertInstanceOf(Car::class, $passenger->vehicle);
     }
 }

--- a/tests/Features/PolymorphismTest.php
+++ b/tests/Features/PolymorphismTest.php
@@ -145,6 +145,23 @@ class PolymorphismTest extends TestCase
         $vehicle->parts()->create(['type' => 'some']);
         $vehicle->parts()->create(['type' => 'other']);
 
+        // This already works today, but it's pretty ugly
+        $passenger = Passenger::query()->where(function ($query) {
+            $query->orWhereHas('car.parts', function ($query) {
+                $query->where('type', 'tire');
+            })->orWhereHas('vehicle.parts', function ($query) {
+                $query->where('type', 'tire');
+            });
+        })->first();
+
+        $this->assertNotNull($passenger);
+        $this->assertTrue($joe->is($passenger));
+        $this->assertTrue($car->is($passenger->vehicle));
+        $this->assertInstanceOf(Car::class, $passenger->vehicle);
+
+        unset($passenger);
+
+        // This works with the new version
         $passenger = Passenger::query()->whereHas('vehicle.parts', function ($query) {
             $query->where('type', 'tire');
         })->first();

--- a/tests/Features/PolymorphismTest.php
+++ b/tests/Features/PolymorphismTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tightenco\Parental\Tests\Features;
+
+use Tightenco\Parental\Tests\Models\Car;
+use Tightenco\Parental\Tests\Models\Part;
+use Tightenco\Parental\Tests\Models\Vehicle;
+use Tightenco\Parental\Tests\TestCase;
+
+class PolymorphismTest extends TestCase
+{
+    /** @test */
+    public function morph_by_many()
+    {
+        Vehicle::create()->parts()->create([]);
+        Car::create()->parts()->create([]);
+
+        $parts = Part::with('vehicles')->get();
+
+        $vehicle = $parts->first()->vehicles->first();
+        $this->assertInstanceOf(Vehicle::class, $vehicle);
+
+        $car = $parts->last()->vehicles->first();
+        $this->assertInstanceOf(Car::class, $car);
+
+        /** @var Part $part */
+        $part = Part::create();
+        $part->vehicles()->attach($vehicle);
+        $part->vehicles()->attach($car);
+
+        $part = Part::find($part->getKey());
+
+        $this->assertTrue($vehicle->is($part->vehicles()->first()));
+        $this->assertInstanceOf(Vehicle::class, $part->vehicles()->first());
+
+        $this->assertTrue($car->is($part->vehicles()->get()->pop()));
+        $this->assertInstanceOf(Car::class, $part->vehicles()->get()->pop());
+    }
+}

--- a/tests/Models/Part.php
+++ b/tests/Models/Part.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Part extends Model
 {
+    protected $guarded = [];
+
     public function vehicles()
     {
         return $this->morphedByMany(Vehicle::class, 'partable', 'vehicle_parts');

--- a/tests/Models/Part.php
+++ b/tests/Models/Part.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tightenco\Parental\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Part extends Model
+{
+    public function vehicles()
+    {
+        return $this->morphedByMany(Vehicle::class, 'partable', 'vehicle_parts');
+    }
+}

--- a/tests/Models/Vehicle.php
+++ b/tests/Models/Vehicle.php
@@ -33,4 +33,9 @@ class Vehicle extends Model
     {
         return $this->belongsToMany(Trip::class);
     }
+
+    public function parts()
+    {
+        return $this->morphToMany(Part::class, 'partable', 'vehicle_parts');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,5 +66,17 @@ class TestCase extends BaseTestCase
             $table->increments('id');
             $table->timestamps();
         });
+
+        Schema::create('parts', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('vehicle_parts', function ($table) {
+            $table->increments('id');
+            $table->integer('part_id');
+            $table->morphs('partable');
+            $table->timestamps();
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,6 +69,7 @@ class TestCase extends BaseTestCase
 
         Schema::create('parts', function ($table) {
             $table->increments('id');
+            $table->string('type')->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
If the parent is designed to return children, then the children will use the parent's morph class.

Probably solves #10

Without this change, using whereHas doesn't always work on children classes. Unless you do something like this:
```php
// ugly
$passenger = Passenger::query()->where(function ($query) {
    $query->orWhereHas('car.parts', function ($query) {
        $query->where('type', 'tire');
    })->orWhereHas('vehicle.parts', function ($query) {
        $query->where('type', 'tire');
    });
})->first();
```

instead of just this:
```php
// a little better
$passenger = Passenger::query()->whereHas('vehicle.parts', function ($query) {
    $query->where('type', 'tire');
})->first();
```

PS: could you tag a new release ?

Thanks
