### PR TITLE
Fix for default childColumn value

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -85,7 +85,7 @@ trait HasChildren
 
     public function getInheritanceColumn()
     {
-        return $this->childColumn ?: 'type';
+        return property_exists($this, 'childColumn') ? $this->childColumn : 'type';
     }
 
     protected function getChildModel(array $attributes)


### PR DESCRIPTION
Right now, when you don't specify your `$childColumn` in your parent model, the model breaks despite default value in source code and the documentation.

This PR fixes that and uses the default value if not set.