### PR TITLE
Add child global scopes when querying parent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/database": "~5.6.0|~5.7.0"
+        "illuminate/database": "~5.6.0|~5.7.0",
+        "hanneskod/classtools": "~1.0"
     },
     "require-dev": {
         "orchestra/testbench": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,12 @@
         "psr-4": {
             "Tightenco\\Parental\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Tightenco\\Parental\\Providers\\ParentalServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edb01492b8f207b1b587f76781f1ebb4",
+    "content-hash": "84608943c0767c9deb20ba059c974f3e",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -278,6 +278,54 @@
                 "parser"
             ],
             "time": "2018-03-08T01:11:30+00:00"
+        },
+        {
+            "name": "hanneskod/classtools",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hanneskod/classtools.git",
+                "reference": "4fba4476ff140af08ddd5ed1a42332b4bc8dcca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hanneskod/classtools/zipball/4fba4476ff140af08ddd5ed1a42332b4bc8dcca9",
+                "reference": "4fba4476ff140af08ddd5ed1a42332b4bc8dcca9",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4",
+                "php": ">=7.1",
+                "symfony/finder": "^4"
+            },
+            "require-dev": {
+                "hanneskod/readme-tester": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "hanneskod\\classtools\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Hannes Forsgård",
+                    "email": "hannes.forsgard@fripost.org"
+                }
+            ],
+            "description": "Find, extract and process classes from file system",
+            "homepage": "https://github.com/hanneskod/classtools",
+            "keywords": [
+                "class finder",
+                "code generator",
+                "metaprogramming",
+                "minimizer"
+            ],
+            "time": "2018-10-25T09:31:36+00:00"
         },
         {
             "name": "laravel/framework",
@@ -635,6 +683,57 @@
                 "time"
             ],
             "time": "2018-08-07T08:39:47+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
+                "reference": "594bcae1fc0bccd3993d2f0d61a018e26ac2865a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2019-01-12T16:31:37+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/config/parental.php
+++ b/config/parental.php
@@ -1,9 +1,12 @@
 <?php
 
 return [
+    // The directories that will be analyzed to find models.
     'model_directories' => [
         app_path(),
     ],
 
+    // Please leave the //just an anchor comment. If you're good with regex or know a good way to easily re-write
+    // the discovered children, please submit an issue or PR.
     'discovered_children' => [], //just an anchor
 ];

--- a/config/parental.php
+++ b/config/parental.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'model_directories' => [
+        app_path(),
+    ],
+
+    'discovered_children' => [], //just an anchor
+];

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,15 @@ It's a fancy name for a simple concept: Extending a model (usually to add specif
 composer require "tightenco/parental=0.6"
 ```
 
+Each time you add or remove child classes, you'll want to do the following:
+```bash
+php artisan parental:discover-children
+```
+
+This artisan command will simplify the following:
+- Laravel Nova resource inheritance (when children don't already have a dedicated Nova resource)
+- Adding child global scopes when querying parent
+
 ## Simple Usage
 
 ```php
@@ -129,20 +138,6 @@ class User extends Model
     protected $fillable = ['parental_type'];
 
     protected $childColumn = 'parental_type';
-}
-```
-
-## Laravel Nova Support
-If you want to use share parent Nova resources with child models, you may register the following provider at the end of the boot method of your NovaServiceProvider:
-
-```php
-class NovaServiceProvider extends NovaApplicationServiceProvider
-{
-    public function boot() {
-        parent::boot();
-        // ...
-        $this->app->register(\Tightenco\Parental\Providers\NovaResourceProvider::class);
-    }
 }
 ```
 

--- a/src/Commands/DiscoverChildren.php
+++ b/src/Commands/DiscoverChildren.php
@@ -26,8 +26,6 @@ class DiscoverChildren extends Command
 
     public function handle()
     {
-        $children = $this->findChildren();
-
         if (! file_exists(config_path('parental.php'))) {
             $this->files->put(
                 config_path('parental.php'),
@@ -36,7 +34,7 @@ class DiscoverChildren extends Command
         }
 
         $content = $this->files->get(config_path('parental.php'));
-        $asString  = "'discovered_children' => ".var_export($children, true).', //just an anchor';
+        $asString  = "'discovered_children' => ".var_export($this->findChildren(), true).', //just an anchor';
 
         $content = preg_replace("/\'discovered_children\' => .*, \/\/just an anchor/", $asString, $content);
 

--- a/src/Commands/DiscoverChildren.php
+++ b/src/Commands/DiscoverChildren.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tightenco\Parental\Commands;
+
+use hanneskod\classtools\Iterator\ClassIterator;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Finder\Finder;
+use Tightenco\Parental\HasChildren;
+use Tightenco\Parental\HasParent;
+use Illuminate\Contracts\Filesystem\Filesystem;
+
+class DiscoverChildren extends Command
+{
+    protected $files;
+
+    protected $signature = 'parental:discover-children';
+
+    protected $description = 'Discover the child models of parent classes using the HasChildren trait.';
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle()
+    {
+        $children = $this->findChildren();
+
+        if (! file_exists(config_path('parental.php'))) {
+            $this->files->put(
+                config_path('parental.php'),
+                $this->files->get(__DIR__.'/../../config/parental.php')
+            );
+        }
+
+        $content = $this->files->get(config_path('parental.php'));
+        $asString  = "'discovered_children' => ".var_export($children, true).', //just an anchor';
+
+        $content = preg_replace("/\'discovered_children\' => .*, \/\/just an anchor/", $asString, $content);
+
+        $this->files->put(config_path('parental.php'), $content);
+
+        return true;
+    }
+
+    public function findChildren()
+    {
+        $finder = new Finder;
+        $iter = new ClassIterator($finder->in(config('parental.model_directories', [])));
+        $children = [];
+
+        foreach ($iter->getClassMap() as $class => $fileInfo) {
+            try {
+                if (! is_a($class, Model::class, true)) {
+                    continue;
+                }
+                $traits = class_uses_recursive($class);
+
+                if (in_array(HasParent::class, $traits) // It's a child
+                    && in_array(HasChildren::class, $traits) // and the parent has the parent trait
+                ) {
+                    $parent = get_parent_class($class);
+                    $children[$parent][$class] = $class;
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        return $children;
+    }
+}

--- a/src/Commands/DiscoverChildren.php
+++ b/src/Commands/DiscoverChildren.php
@@ -8,37 +8,25 @@ use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Finder\Finder;
 use Tightenco\Parental\HasChildren;
 use Tightenco\Parental\HasParent;
-use Illuminate\Contracts\Filesystem\Filesystem;
 
 class DiscoverChildren extends Command
 {
-    protected $files;
-
     protected $signature = 'parental:discover-children';
 
     protected $description = 'Discover the child models of parent classes using the HasChildren trait.';
 
-    public function __construct(Filesystem $files)
-    {
-        parent::__construct();
-        $this->files = $files;
-    }
-
     public function handle()
     {
         if (! file_exists(config_path('parental.php'))) {
-            $this->files->put(
-                config_path('parental.php'),
-                $this->files->get(__DIR__.'/../../config/parental.php')
-            );
+            file_put_contents(config_path('parental.php'), file_get_contents(__DIR__.'/../../config/parental.php'));
         }
 
-        $content = $this->files->get(config_path('parental.php'));
+        $content = file_get_contents(config_path('parental.php'));
         $asString  = "'discovered_children' => ".var_export($this->findChildren(), true).', //just an anchor';
 
         $content = preg_replace("/\'discovered_children\' => .*, \/\/just an anchor/", $asString, $content);
 
-        $this->files->put(config_path('parental.php'), $content);
+        file_put_contents(config_path('parental.php'), $content);
 
         return true;
     }

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -12,11 +12,11 @@ trait HasChildren
     {
         if (static::class === self::class) {
             foreach ((new self)->getChildTypes() as $childClass) {
-                // Just booting all the child classes to "inherit" their global scopes
+                // Just booting all the child classes to make sure their base global scopes get registered
                 new $childClass;
             }
 
-            static::addGlobalScope('remainingChildrenScope', ParentScope::addMissingChildren(self::class));
+            static::addGlobalScope(new ParentScope);
         }
     }
 

--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -51,11 +51,11 @@ trait HasChildren
     {
         $instance = $this->newRelatedInstance($related);
 
-        if (is_null($foreignKey) && $instance->hasParent) {
+        if ($foreignKey === null && $instance->hasParent) {
             $foreignKey = Str::snake($instance->getClassNameForRelationships()).'_'.$instance->getKeyName();
         }
 
-        if (is_null($relation)) {
+        if ($relation === null) {
             $relation = $this->guessBelongsToRelation();
         }
 
@@ -71,7 +71,7 @@ trait HasChildren
     {
         $instance = $this->newRelatedInstance($related);
 
-        if (is_null($table) && $instance->hasParent) {
+        if ($table === null && $instance->hasParent) {
             $table = $this->joiningTable($instance->getClassNameForRelationships());
         }
 

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -34,7 +34,9 @@ trait HasParent
         $child = new static;
 
         if ($scope !== 'parental' && $child->parentHasHasChildrenTrait()) {
-            ParentScope::registerChild($child, $implementation);
+            $key = array_search($implementation, static::$globalScopes[static::class]);
+            $key = $child->classToAlias(static::class).':'.$key;
+            ParentScope::registerChild($child, $key, $implementation);
         }
 
         return $implementation;

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -31,12 +31,10 @@ trait HasParent
     public static function addGlobalScope($scope, \Closure $implementation = null)
     {
         $implementation = parent::addGlobalScope($scope, $implementation);
-        $key = array_search($implementation, static::$globalScopes[static::class]);
         $child = new static;
 
         if ($scope !== 'parental' && $child->parentHasHasChildrenTrait()) {
-            $parent = $child->getParentClass();
-            $parent::addGlobalScope(static::class.':'.$key, ParentScope::passToParent($parent, $child, $implementation));
+            ParentScope::registerChild($child, $implementation);
         }
 
         return $implementation;

--- a/src/ParentScope.php
+++ b/src/ParentScope.php
@@ -42,10 +42,12 @@ class ParentScope
     public static function addMissingChildren(string $parent)
     {
         return function (Builder $builder) use ($parent) {
-            $instance = new $parent;
+            if (! isset(static::$registered[$parent])) {
+                return;
+            }
 
-            $registeredChildren = isset(static::$registered[$parent]) ? static::$registered[$parent] : [];
-            $missingChildren = array_diff($instance->getChildTypes(), $registeredChildren);
+            $instance = new $parent;
+            $missingChildren = array_diff($instance->getChildTypes(), static::$registered[$parent]);
 
             $builder->orWhereIn($instance->getInheritanceColumn(), array_keys($missingChildren))
                     ->orWhereNull($instance->getInheritanceColumn());

--- a/src/ParentScope.php
+++ b/src/ParentScope.php
@@ -6,51 +6,43 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 
-class ParentScope
+class ParentScope implements Scope
 {
-    protected $child;
-    protected $implementation;
-
     protected static $registered = [];
 
-    protected function __construct(Model $child, $implementation)
+    public function apply(Builder $builder, Model $parent)
     {
-        $this->child = $child;
-        $this->implementation = $implementation;
-    }
-
-    protected function apply(Builder $builder)
-    {
-        $builder->orWhere($this->child->getInheritanceColumn(), $this->child->classToAlias(get_class($this->child)));
-
-        if ($this->implementation instanceof \Closure) {
-            ($this->implementation)($builder);
-        } elseif ($this->implementation instanceof Scope) {
-            $this->implementation->apply($builder, $builder->getModel());
+        if (! isset(static::$registered[get_class($parent)])) {
+            return;
         }
-    }
 
-    public static function passToParent(string $parent, Model $child, $implementation)
-    {
-        static::$registered[$parent][] = get_class($child);
+        $builder->where(function (Builder $builder) use ($parent) {
+            $childColumn = $parent->getInheritanceColumn();
 
-        return function (Builder $builder) use ($child, $implementation) {
-            (new static($child, $implementation))->apply($builder);
-        };
-    }
+            foreach (static::$registered[get_class($parent)] as $alias => $implementations) {
+                foreach ($implementations as $implementation) {
+                    $builder->orWhere(function (Builder $builder) use ($childColumn, $alias, $implementation) {
+                        $builder->where($childColumn, $alias);
 
-    public static function addMissingChildren(string $parent)
-    {
-        return function (Builder $builder) use ($parent) {
-            if (! isset(static::$registered[$parent])) {
-                return;
+                        if ($implementation instanceof \Closure) {
+                            ($implementation)($builder);
+                        } elseif ($implementation instanceof Scope) {
+                            $implementation->apply($builder, $builder->getModel());
+                        }
+                    });
+                }
             }
 
-            $instance = new $parent;
-            $missingChildren = array_diff($instance->getChildTypes(), static::$registered[$parent]);
+            $builder->orWhere(function (Builder $builder) use ($parent, $childColumn) {
+                $missingChildren = array_diff_key($parent->getChildTypes(), static::$registered[get_class($parent)]);
+                $builder->orWhereIn($childColumn, array_keys($missingChildren))
+                        ->orWhereNull($childColumn);
+            });
+        });
+    }
 
-            $builder->orWhereIn($instance->getInheritanceColumn(), array_keys($missingChildren))
-                    ->orWhereNull($instance->getInheritanceColumn());
-        };
+    public static function registerChild(Model $child, $implementation)
+    {
+        static::$registered[get_parent_class($child)][$child->classToAlias(get_class($child))][] = $implementation;
     }
 }

--- a/src/ParentScope.php
+++ b/src/ParentScope.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tightenco\Parental;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ParentScope
+{
+    private $child;
+    private $implementation;
+
+    protected static $registered = [];
+
+    protected function __construct(Model $child, $implementation)
+    {
+        $this->child = $child;
+        $this->implementation = $implementation;
+    }
+
+    protected function apply(Builder $builder) : void
+    {
+        $builder->orWhere($this->child->getInheritanceColumn(), $this->child->classToAlias(get_class($this->child)));
+
+        if ($this->implementation instanceof \Closure) {
+            ($this->implementation)($builder);
+        } elseif ($this->implementation instanceof Scope) {
+            $this->implementation->apply($builder, $builder->getModel());
+        }
+    }
+
+    public static function passToParent(string $parent, Model $child, $implementation)
+    {
+        static::$registered[$parent][] = get_class($child);
+
+        return function (Builder $builder) use ($child, $implementation) {
+            (new static($child, $implementation))->apply($builder);
+        };
+    }
+
+    public static function addMissingChildren(string $parent)
+    {
+        return function (Builder $builder) use ($parent) {
+            $instance = new $parent;
+
+            $registeredChildren = isset(static::$registered[$parent]) ? static::$registered[$parent] : [];
+            $missingChildren = array_diff($instance->getChildTypes(), $registeredChildren);
+
+            $builder->orWhereIn($instance->getInheritanceColumn(), array_keys($missingChildren))
+                    ->orWhereNull($instance->getInheritanceColumn());
+        };
+    }
+}

--- a/src/ParentScope.php
+++ b/src/ParentScope.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Scope;
 
 class ParentScope
 {
-    private $child;
-    private $implementation;
+    protected $child;
+    protected $implementation;
 
     protected static $registered = [];
 
@@ -19,7 +19,7 @@ class ParentScope
         $this->implementation = $implementation;
     }
 
-    protected function apply(Builder $builder) : void
+    protected function apply(Builder $builder)
     {
         $builder->orWhere($this->child->getInheritanceColumn(), $this->child->classToAlias(get_class($this->child)));
 

--- a/src/Providers/ParentalServiceProvider.php
+++ b/src/Providers/ParentalServiceProvider.php
@@ -4,18 +4,37 @@ namespace Tightenco\Parental\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nova\Nova;
+use Tightenco\Parental\Commands\DiscoverChildren;
 use Tightenco\Parental\HasChildren;
 use Tightenco\Parental\HasParent;
 
-class NovaResourceProvider extends ServiceProvider
+class ParentalServiceProvider extends ServiceProvider
 {
     public function boot()
     {
         if (class_exists(Nova::class)) {
+           $this->extendParentNovaResourcesToChildren();
+        }
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([__DIR__.'/../../config/parental.php' => config_path('parental.php')]);
+        }
+    }
+
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/parental.php', 'parental');
+        $this->commands([DiscoverChildren::class]);
+    }
+
+    protected function extendParentNovaResourcesToChildren()
+    {
+        // We want to ensure that this bit of code runs after resources are registered in Nova
+        $this->app->booted(function () {
             Nova::serving(function () {
                 $this->setNovaResources();
             });
-        }
+        });
     }
 
     protected function setNovaResources()

--- a/tests/Features/ParentModelInheritsChildrenScopes.php
+++ b/tests/Features/ParentModelInheritsChildrenScopes.php
@@ -15,7 +15,7 @@ class ParentModelInheritsChildrenScopes extends TestCase
         $this->createTenTrips();
 
         $this->assertEquals(10, Trip::query()->count());
-        $this->assertCount(2, (new Trip)->getGlobalScopes());
+        $this->assertCount(1, (new Trip)->getGlobalScopes());
     }
 
     /** @test */
@@ -29,7 +29,8 @@ class ParentModelInheritsChildrenScopes extends TestCase
         });
 
         $this->assertEquals(10, Trip::query()->count());
-        $this->assertCount(3, (new Trip)->getGlobalScopes());
+        $this->assertCount(1, (new Trip)->getGlobalScopes());
+        $this->assertCount(2, (new LocalTrip)->getGlobalScopes());
     }
 
     /** @test */
@@ -42,26 +43,44 @@ class ParentModelInheritsChildrenScopes extends TestCase
         });
 
         $this->assertEquals(8, Trip::query()->count());
-        $this->assertCount(3, (new Trip)->getGlobalScopes());
+        $this->assertCount(1, (new Trip)->getGlobalScopes());
+        $this->assertCount(2, (new LocalTrip)->getGlobalScopes());
 
         $localTrip = LocalTrip::query()->first();
 
         $this->assertEquals(9, $localTrip->getKey());
     }
 
+    /** @test */
+    public function can_modify_query()
+    {
+        $this->createTenTrips();
+
+        LocalTrip::addGlobalScope(function ($q) {
+            $q->whereKey(9);
+        });
+
+        $trips = Trip::query()->where('duration', '>=', 3)->get();
+
+        $this->assertCount(3, $trips);
+        $this->assertInstanceOf(Trip::class, $trips->shift());
+        $this->assertInstanceOf(Trip::class, $trips->shift());
+        $this->assertInstanceOf(InternationalTrip::class, $trips->shift());
+    }
+
     private function createTenTrips()
     {
-        Trip::query()->create();
-        Trip::query()->create();
-        Trip::query()->create();
-        Trip::query()->create();
+        Trip::query()->create(['duration' => 1]);
+        Trip::query()->create(['duration' => 2]);
+        Trip::query()->create(['duration' => 3]);
+        Trip::query()->create(['duration' => 4]);
 
-        InternationalTrip::query()->create();
-        InternationalTrip::query()->create();
-        InternationalTrip::query()->create();
+        InternationalTrip::query()->create(['duration' => 1]);
+        InternationalTrip::query()->create(['duration' => 2]);
+        InternationalTrip::query()->create(['duration' => 3]);
 
-        LocalTrip::query()->create();
-        LocalTrip::query()->create();
-        LocalTrip::query()->create();
+        LocalTrip::query()->create(['duration' => 1]);
+        LocalTrip::query()->create(['duration' => 2]);
+        LocalTrip::query()->create(['duration' => 3]);
     }
 }

--- a/tests/Features/ParentModelInheritsChildrenScopes.php
+++ b/tests/Features/ParentModelInheritsChildrenScopes.php
@@ -33,7 +33,7 @@ class ParentModelInheritsChildrenScopes extends TestCase
     }
 
     /** @test */
-    public function child_scopes_apply_on_parent_queries_for_given_child()
+    public function child_scopes_apply_on_parent_queries()
     {
         $this->createTenTrips();
 

--- a/tests/Features/ParentModelInheritsChildrenScopes.php
+++ b/tests/Features/ParentModelInheritsChildrenScopes.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tightenco\Parental\Tests\Features;
+
+use Tightenco\Parental\Tests\Models\InternationalTrip;
+use Tightenco\Parental\Tests\Models\LocalTrip;
+use Tightenco\Parental\Tests\Models\Trip;
+use Tightenco\Parental\Tests\TestCase;
+
+class ParentModelInheritsChildrenScopes extends TestCase
+{
+    /** @test */
+    public function simple_scope_inheritance_check()
+    {
+        $this->createTenTrips();
+
+        $this->assertEquals(10, Trip::query()->count());
+        $this->assertCount(2, (new Trip)->getGlobalScopes());
+    }
+
+    /** @test */
+    public function global_scopes_can_be_added_on_the_fly()
+    {
+        $this->createTenTrips();
+
+        LocalTrip::addGlobalScope(function ($query) {
+            // this doesn't actually do anything to the query
+            $query->whereNotNull((new LocalTrip)->getInheritanceColumn());
+        });
+
+        $this->assertEquals(10, Trip::query()->count());
+        $this->assertCount(3, (new Trip)->getGlobalScopes());
+    }
+
+    /** @test */
+    public function child_scopes_apply_on_parent_queries_for_given_child()
+    {
+        $this->createTenTrips();
+
+        LocalTrip::addGlobalScope(function ($q) {
+            $q->whereKey(9);
+        });
+
+        $this->assertEquals(8, Trip::query()->count());
+        $this->assertCount(3, (new Trip)->getGlobalScopes());
+
+        $localTrip = LocalTrip::query()->first();
+
+        $this->assertEquals(9, $localTrip->getKey());
+    }
+
+    private function createTenTrips()
+    {
+        Trip::query()->create();
+        Trip::query()->create();
+        Trip::query()->create();
+        Trip::query()->create();
+
+        InternationalTrip::query()->create();
+        InternationalTrip::query()->create();
+        InternationalTrip::query()->create();
+
+        LocalTrip::query()->create();
+        LocalTrip::query()->create();
+        LocalTrip::query()->create();
+    }
+}

--- a/tests/Features/ParentModelInheritsChildrenScopes.php
+++ b/tests/Features/ParentModelInheritsChildrenScopes.php
@@ -15,7 +15,7 @@ class ParentModelInheritsChildrenScopes extends TestCase
         $this->createTenTrips();
 
         $this->assertEquals(10, Trip::query()->count());
-        $this->assertCount(1, (new Trip)->getGlobalScopes());
+        $this->assertCount(2, (new Trip)->getGlobalScopes());
     }
 
     /** @test */
@@ -29,8 +29,8 @@ class ParentModelInheritsChildrenScopes extends TestCase
         });
 
         $this->assertEquals(10, Trip::query()->count());
-        $this->assertCount(1, (new Trip)->getGlobalScopes());
-        $this->assertCount(2, (new LocalTrip)->getGlobalScopes());
+        $this->assertCount(2, (new Trip)->getGlobalScopes());
+        $this->assertCount(3, (new LocalTrip)->getGlobalScopes());
     }
 
     /** @test */
@@ -43,8 +43,8 @@ class ParentModelInheritsChildrenScopes extends TestCase
         });
 
         $this->assertEquals(8, Trip::query()->count());
-        $this->assertCount(1, (new Trip)->getGlobalScopes());
-        $this->assertCount(2, (new LocalTrip)->getGlobalScopes());
+        $this->assertCount(2, (new Trip)->getGlobalScopes());
+        $this->assertCount(3, (new LocalTrip)->getGlobalScopes());
 
         $localTrip = LocalTrip::query()->first();
 

--- a/tests/Features/ParentsObserveChildrenTest.php
+++ b/tests/Features/ParentsObserveChildrenTest.php
@@ -23,7 +23,7 @@ class ParentsObserveChildrenTest extends TestCase
         $this->assertEquals(1, $vehicle->driver_id);
 
         $train = Train::create();
-        $this->assertNull($train->driver_id);
+        $this->assertEquals(1, $train->driver_id);
     }
 
     /** @test */
@@ -64,7 +64,7 @@ class ParentsObserveChildrenTest extends TestCase
         $this->assertEquals(3, $vehicle->driver_id);
 
         $train = Train::create();
-        $this->assertNull($train->driver_id);
+        $this->assertEquals(3, $train->driver_id);
     }
 
     /** @test */

--- a/tests/Models/InternationalTrip.php
+++ b/tests/Models/InternationalTrip.php
@@ -8,4 +8,13 @@ use Tightenco\Parental\HasParent;
 class InternationalTrip extends Trip
 {
     use HasParent;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope(function ($query) {
+            $query->whereNotNull('id');
+        });
+    }
 }

--- a/tests/Models/LocalTrip.php
+++ b/tests/Models/LocalTrip.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tightenco\Parental\Tests\Models;
+
+use Tightenco\Parental\HasParent;
+
+class LocalTrip extends Trip
+{
+    use HasParent;
+}

--- a/tests/Models/Trip.php
+++ b/tests/Models/Trip.php
@@ -18,7 +18,7 @@ class Trip extends Model
         parent::boot();
 
         static::addGlobalScope('verification', function ($query) {
-            $query->whereNotNull(static::CREATED_AT);
+            $query->whereNotNull('trips.id');
         });
     }
 

--- a/tests/Models/Trip.php
+++ b/tests/Models/Trip.php
@@ -13,6 +13,15 @@ class Trip extends Model
 
     protected $guarded = [];
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('verification', function ($query) {
+            $query->whereNotNull(static::CREATED_AT);
+        });
+    }
+
     public function vehicles()
     {
         return $this->belongsToMany(Vehicle::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,7 @@ class TestCase extends BaseTestCase
         Schema::create('trips', function ($table) {
             $table->increments('id');
             $table->integer('trip_type')->nullable();
+            $table->integer('duration')->default(1);
             $table->timestamps();
         });
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,8 @@ namespace Tightenco\Parental\Tests;
 
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Tightenco\Parental\Commands\DiscoverChildren;
+use Tightenco\Parental\Tests\Models\Vehicle;
 
 class TestCase extends BaseTestCase
 {
@@ -25,6 +27,10 @@ class TestCase extends BaseTestCase
             'database' => ':memory:',
             'prefix'   => '',
         ]);
+
+        config()->set('parental.model_directories', __DIR__.'/Models');
+        $children = $app->make(DiscoverChildren::class)->findChildren();
+        config()->set('parental.discovered_children', array_merge(config('parental.discovered_children', []), $children));
     }
 
     public function runMigrations()


### PR DESCRIPTION
This PR does the following:
- Add global scopes when querying parent (see #6)
- Remove the need of manually registering a service provider for Nova
- Parent events are registered on children whether the children are declared in childTypes or not
- Add a command to find all child models (required for the above changes if you don't register the child types on the parents)
