### PR TITLE
Add failing test demonstrating double registering of events

### DIFF
--- a/tests/Features/ParentsObserveChildrenTest.php
+++ b/tests/Features/ParentsObserveChildrenTest.php
@@ -83,4 +83,14 @@ class ParentsObserveChildrenTest extends TestCase
         $train = Train::create();
         $this->assertNull($train->driver_id);
     }
+
+    /** @test */
+    public function registering_events_in_parent_boot_only_triggers_once()
+    {
+        $vehicle = Vehicle::create();
+        $this->assertEquals(1, $vehicle->boot_count);
+
+        $car = Car::create();
+        $this->assertEquals(1, $car->boot_count);
+    }
 }

--- a/tests/Models/Vehicle.php
+++ b/tests/Models/Vehicle.php
@@ -19,6 +19,15 @@ class Vehicle extends Model
 
     protected $guarded = [];
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::created(function ($model) {
+            $model->boot_count = $model->boot_count ? $model->boot_count + 1 : 1;
+        });
+    }
+
     public function driver()
     {
         return $this->belongsTo(Driver::class);


### PR DESCRIPTION
This PR is a failing test demonstrating the issue described in #37.

This issue causes problems when using a library like spatie/laravel-activitylog. In this library specifically, it is possible for children to trigger double activities.

I am not sure how best to solve - ideas welcome!