### PR TITLE
add test suffix to test cases

### DIFF
--- a/tests/Features/PolymorphismTest.php
+++ b/tests/Features/PolymorphismTest.php
@@ -76,7 +76,7 @@ class PolymorphismTest extends TestCase
     public function can_query_deeply_from_parental_models_to_morphed_via_where_has()
     {
         $car = Car::create();
-        $passenger = $car->passengers()->create(['name' => 'joe']);
+        $car->passengers()->create(['name' => 'joe']);
         $car->parts()->create(['type' => 'tire']);
 
         $passenger = Passenger::query()->whereHas('vehicle.parts', function ($query) {

--- a/tests/Features/TypeColumnCanBeAliasedTest.php
+++ b/tests/Features/TypeColumnCanBeAliasedTest.php
@@ -7,7 +7,7 @@ use Tightenco\Parental\Tests\Models\Plane;
 use Tightenco\Parental\Tests\Models\Vehicle;
 use Tightenco\Parental\Tests\TestCase;
 
-class TypeColumnCanBeAliased extends TestCase
+class TypeColumnCanBeAliasedTest extends TestCase
 {
     /** @test */
     function type_column_values_can_accept_type_aliases()

--- a/tests/Features/TypeColumnGetsSetAutomaticallyTest.php
+++ b/tests/Features/TypeColumnGetsSetAutomaticallyTest.php
@@ -8,7 +8,7 @@ use Tightenco\Parental\Tests\Models\InternationalTrip;
 use Tightenco\Parental\Tests\Models\Trip;
 use Tightenco\Parental\Tests\TestCase;
 
-class TypeColumnGetsSetAutomatically extends TestCase
+class TypeColumnGetsSetAutomaticallyTest extends TestCase
 {
     /** @test */
     function type_column_gets_set_on_creation()


### PR DESCRIPTION
Some test cases don't run because the way phpunit is configured, it's looking for test classes with the suffix of Test. This PR just adds those suffixes.