### PR TITLE
Use getChildTypes method to allow method overriding

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -14,11 +14,13 @@ trait HasChildren
     {
         parent::registerModelEvent($event, $callback);
 
-        if (static::class === self::class && property_exists(self::class, 'childTypes')) {
+        $childTypes = (new self)->getChildTypes();
+
+        if (static::class === self::class && count($childTypes)) {
             // We don't want to register the callbacks that happen in the boot method of the parent, as they'll be called
             // from the child's boot method as well.
             if (! self::parentIsBooting()) {
-                foreach ((new self)->childTypes as $childClass) {
+                foreach ($childTypes as $childClass) {
                     $childClass::registerModelEvent($event, $callback);
                 }
             }


### PR DESCRIPTION
We define our child types based on values from [phpenum](http://github.com/myclabs/php-enum), however all constants are marked as private and cannot be used outside of the enum (this enforces us the use the method instead of the private constant).

But expressions are not allowed as field default values, so we would like to override the getChildTypes method.

e.g.
```php
...

class Vehicle extends Model
{
    use HasChildren;

   protected $childTypes = [
        EnumVehicle::CAR => Car::class
   ];
}
```

Becomes in our case 
e.g.
```php
...

class Vehicle extends Model
{
    use HasChildren;

    public function getChildTypes(): array
    {
          return [
              EnumVehicle::CAR()->getValue() => Car::class
          ];
    }
}
```